### PR TITLE
Avoid writing too many files at the same time

### DIFF
--- a/bin/blogger2jekyll.js
+++ b/bin/blogger2jekyll.js
@@ -30,7 +30,7 @@
       ;
     
     // write the files out flat, the static compiler with write out the folders
-    fs.writeFile(path.join(folder, filename), contents, 'utf8');
+    fs.writeFileSync(path.join(folder, filename), contents, 'utf8');
   }
 
   function parseFile(err, data) {


### PR DESCRIPTION
This fixes

```
fs.js:75
      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
            ^
Error: EMFILE, open
```
