### PR TITLE
Break YAML into a separate array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,23 +65,37 @@
           );
         });
 
-        contents = [
-            '---'
-          , 'uuid: "' + post.uuid + '"'
+        yaml = [
+            'uuid: "' + post.uuid + '"'
           , 'title: "' + post.title.replace(/"/g, '\\"') + '"'
           , 'date: "' + post.published.toISOString().replace(/[ T].*/, '') + '"'
           , 'permalink: "' + path.normalize(prefix + '/' + post.permalink) + '"'
           , 'description: '
           , 'categories: '
+        ];
+
+        if (post.draft)
+          yaml.push( 'published: "false"' );
+
+        contents = ['---'];
+        
+        contents = contents.concat(yaml);
+
+        contents = contents.concat([
           , '---'
           , ''
           , '<div class="css-full-post-content js-full-post-content">'
           , post.content
           , '</div>'
-          , '<div class="css-full-comments-content js-full-comments-content">'
-          , subcontents.join('\n')
-          , '</div>'
-        ];
+        ]);
+        
+        if ( subcontents.length > 0 ) {
+          contents = contents.concat([
+          	  '<div class="css-full-comments-content js-full-comments-content">'
+          	, subcontents.join('\n')
+          	, '</div>'
+          ]);
+        }
 
         eachPost(post.permalink, contents.join('\n'));
       });
@@ -104,6 +118,7 @@
           obj.updated = new Date(entry.updated[0]._);
           obj.title = entry.title[0]._;
           obj.content = entry.content[0]._;
+          obj.draft = ( typeof entry['app:control'] != 'undefined'  &&  typeof entry['app:control'][0] != 'undefined'  && entry['app:control'][0]['app:draft'] == 'yes' );
         }
 
         if (/kind#post/.test(entry.category[0].$.term)) {


### PR DESCRIPTION
If we can break all the YAML header stuff into a separate array, it will be easier to conditionally `push` items into it.

For instance, if a post is a _Draft_, we may want to include the `published: "false"` header, but we don't need to include anything at all if the post is not a draft.
