### PR TITLE
Specify `post` layout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,7 @@
           , 'title: "' + post.title.replace(/"/g, '\\"') + '"'
           , 'date: "' + post.published.toISOString().replace(/[ T].*/, '') + '"'
           , 'permalink: "' + path.normalize(prefix + '/' + post.permalink) + '"'
+          , 'layout: post'
           , 'description: '
           , 'categories: '
           , '---'


### PR DESCRIPTION
Unless we have a good reason not to, we should specify that each post is to use the `post` layout.
Without including this in the YAML front matter, Jekyll won't do much.
