### PR TITLE
Prepend date to filename

### DIFF
--- a/bin/blogger2jekyll.js
+++ b/bin/blogger2jekyll.js
@@ -28,6 +28,15 @@
   function eachPost(relpath, contents) {
     var filename = relpath.split('/').pop()
       ;
+
+    var date=new RegExp(/date\:\s\"([0-9]{4}-[0-9]{2}-[0-9]{2})/)
+      ;
+
+    if ( date.test(contents) && ( contents.indexOf('published: "false"') == -1 ) ) {
+    	filename = date.exec(contents)[1] + '-' + filename;
+    } else {
+	    filename = 'DRAFT' + '-' + filename;
+    }
     
     // write the files out flat, the static compiler with write out the folders
     fs.writeFileSync(path.join(folder, filename), contents, 'utf8');


### PR DESCRIPTION
Jekyll seems to require post filenames to have the date at the beginning.
There is quite likely a nicer way to do this, but this seems to work.
