### PR TITLE
Add Windows support, allow braces in HTML

### DIFF
--- a/bin/blogger2jekyll.js
+++ b/bin/blogger2jekyll.js
@@ -43,7 +43,7 @@
   }
 
   function parseFile(err, data) {
-    b2j.parse(data, eachPost, { prefix: '' });
+    b2j.parse(data, eachPost, { prefix: '', wrapRaw: true });
   }
   
   function readFile(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,8 +131,11 @@
         contents.push(
             '---'
           , ''
-          , '{% raw %}'
-          , '<div class="css-full-post-content js-full-post-content">'
+        );
+        if (opts.wrapRaw)
+          contents.push('{% raw %}');
+        contents.push(
+            '<div class="css-full-post-content js-full-post-content">'
           , post.content
           , '</div>'
         );
@@ -145,7 +148,8 @@
           );
         }
 
-        contents.push('{% endraw %}');
+        if (opts.wrapRaw)
+          contents.push('{% endraw %}');
 
         eachPost(post.permalink, contents.join('\n'));
       });


### PR DESCRIPTION
I fixed an issue with backslashes in URLs; this now works on Windows.

I also added Liquid `{% raw %}` tags around imported HTML so that it doesn't choke on HTML that looks like Liquid inclusions. 
